### PR TITLE
Properly format active job payload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .DS_Store
 local_note.md
 Gemfile.lock
+
+test/stdout
+dump.rdb

--- a/Rakefile
+++ b/Rakefile
@@ -21,9 +21,8 @@ task :default => :test
 
 desc "Run the test suite"
 task :test do
-  rg = command?(:rg)
   Dir['test/**/*_test.rb'].each do |f|
-    rg ? sh("rg #{f}") : ruby(f)
+    ruby(f)
   end
 end
 

--- a/lib/resque_cleaner.rb
+++ b/lib/resque_cleaner.rb
@@ -251,6 +251,13 @@ module Resque
           jobs = [] unless jobs
           jobs = [jobs] unless jobs.is_a?(Array)
           jobs.each{|j| j.extend FailedJobEx}
+
+          # ActiveJob compatibility layer
+          jobs.each do |job|
+            next unless job.dig("payload", "class") == "ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper"
+            job["payload"]["class"] = job.dig("payload", "args", 0, "job_class")
+            job["payload"]["args"] = job.dig("payload", "args", 0, "arguments")
+          end
           jobs
         end
 

--- a/test/resque_web_test.rb
+++ b/test/resque_web_test.rb
@@ -42,6 +42,13 @@ describe "resque-web" do
     assert last_response.ok?, last_response.errors
   end
 
+  it '#cleaner_list shows ActiveJob failed jobs properly formated' do
+    add_activejob_failure
+
+    get "/cleaner_list", :c => "ActiveJobGoodJob"
+    assert last_response.body.include?("ActiveJobGoodJob")
+  end
+
   it '#cleaner_list shows the failed jobs' do
     get "/cleaner_list"
     assert last_response.body.include?('BadJob')

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -129,3 +129,32 @@ def add_empty_payload_failure
   data = Resque.encode(data)
   Resque.redis.rpush(:failed, data)
 end
+
+def add_activejob_failure
+  data = {
+    :failed_at => Time.now.strftime("%Y/%m/%d %H:%M:%S %Z"),
+    :payload   => {
+      :class => "ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper",
+      :args  => [
+        :job_class => "ActiveJobGoodJob",
+        :job_id    => "0bc036ab-32c0-4ad0-9138-abdfb06658c4",
+        :provider_job_id => nil,
+        :queue_name => "download_scrape_job",
+        :priority => nil,
+        :arguments => [:good_job],
+        :executions => 0,
+        :exception_executions => {},
+        :locale => "en",
+        :timezone => "UTC",
+        :enqueued_at => "2020-10-13T16:37:18Z"
+      ]
+    },
+    :exception => "Resque::DirtyExit",
+    :error     => "Resque::DirtyExit",
+    :backtrace => [],
+    :worker    => "worker",
+    :queue     => "queue"
+  }
+  data = Resque.encode(data)
+  Resque.redis.rpush(:failed, data)
+end


### PR DESCRIPTION
This PR adds support for `ActiveJob` jobs, hiding the middleware payload and only exposing the actual job payload. 

Before:
![before](https://user-images.githubusercontent.com/7543345/97005553-fb9f9180-1514-11eb-9b02-474cc12086c3.png)

After:
![after](https://user-images.githubusercontent.com/7543345/97005564-fe9a8200-1514-11eb-87c6-3b7362ce3dcf.png)
