### PR TITLE
deserialize job to default JobWrapper class

### DIFF
--- a/lib/resque_cleaner/server.rb
+++ b/lib/resque_cleaner/server.rb
@@ -230,7 +230,14 @@ module ResqueCleaner
         f: @from,
         t: @to,
         regex: @regex
-      }.map {|key,value| "#{key}=#{URI.encode(value.to_s)}"}.join("&")
+      }
+      
+      if URI.respond_to?(:encode)
+        # ruby < 3.0
+        params = params.map {|key,value| "#{key}=#{URI.encode(value.to_s)}"}.join("&")
+      else
+        params = params.map {|key,value| "#{key}=#{URI.encode_www_form_component(value.to_s)}"}.join("&")
+      end
 
       @list_url = "cleaner_list?#{params}"
       @dump_url = "cleaner_dump?#{params}"

--- a/test/resque_web_test.rb
+++ b/test/resque_web_test.rb
@@ -69,5 +69,17 @@ describe "resque-web" do
     get "/cleaner_dump"
     assert last_response.ok?, last_response.errors
   end
+
+  it "serialize activejob failure" do
+    add_activejob_failure
+
+    get "/cleaner_list", :c => "ActiveJobGoodJob"
+    assert last_response.body.include?("ActiveJobGoodJob")
+
+    post "/cleaner_exec", :c => "ActiveJobGoodJob", :select_all_pages => "1", :action => "retry_and_clear"
+
+    job = Resque::Job.reserve('queue')
+    assert_equal 'ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper', job.payload['class'], job.inspect
+  end
 end
 


### PR DESCRIPTION
The goal of these modification is to fix a bug with failed jobs which have been retried via resque-cleaner with a string in their arguments.

This issue here comes from the serialisation of the job here : https://github.com/h3nnn4n/resque-cleaner/blob/master/lib/resque_cleaner.rb#L248

The job's payload is transformed from 
```
"payload"=>{"class"=>"ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper", "args"=>[{"job_class"=>"<Class of the job>", "arguments"=>[<List of arguments>], ...
```
to 
```
"payload"=>{"class"=>"<Class of the job>", "args"=>[<List of arguments>], ...
```

The default behavior of Resque is to execute the hook `before_perform` (https://github.com/resque/resque/blob/master/lib/resque/job.rb#L156) on the list of arguments, which cannot contain a string argument : https://github.com/rails/rails/blob/main/activesupport/lib/active_support/callbacks.rb#L282

The solution here is to deserialize the job to set the class to the default ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper and pass class and arguments through the payload's arguments
(https://github.com/h3nnn4n/resque-cleaner/pull/2/files#diff-05017260361894f2c824cc83553afe1423b4ce2cfc855f7d9f7b5ffd2ea9cc81R128)

The use case :
We have a failed job :
![Capture d’écran 2021-09-17 à 15 44 11](https://user-images.githubusercontent.com/4319193/133795326-15a00f28-badf-4c0d-a95f-9fa4f05e3f39.png)

We retried them via resque-cleaner :
![Capture d’écran 2021-09-17 à 15 44 33](https://user-images.githubusercontent.com/4319193/133798213-a8c72c22-96a2-41e8-98aa-716a2bfb2df9.png)
 
